### PR TITLE
feat(core) : Add Ticket Order(epic, sprint) API

### DIFF
--- a/apps/core-server/src/database/migrations/1737338308798-Migration.ts
+++ b/apps/core-server/src/database/migrations/1737338308798-Migration.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migration1737338308798 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE \`TB_TICKET\`
+        ADD COLUMN \`epic_order_id\` INT NOT NULL DEFAULT 1;
+    `);
+    await queryRunner.query(`
+        ALTER TABLE \`TB_TICKET\`
+        ADD COLUMN \`sprint_order_id\` INT NOT NULL DEFAULT 1;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE \`TB_TICKET\`
+        DROP COLUMN \`sprint_order_id\`;
+    `);
+    await queryRunner.query(`
+        ALTER TABLE \`TB_TICKET\`
+        DROP COLUMN \`epic_order_id\`;
+    `);
+  }
+}

--- a/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
+++ b/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
@@ -460,6 +460,7 @@ export default class TicketController {
     );
 
     await this.ticketService.updateTicketOrder(
+      'orderId',
       ticket,
       targetTicket.orderId,
       workspaceId,
@@ -486,7 +487,8 @@ export default class TicketController {
       dto.targetTicketId,
     );
 
-    await this.ticketService.updateTicketEpicOrder(
+    await this.ticketService.updateTicketOrder(
+      'epic_order_id',
       ticket,
       targetTicket.epic_order_id,
       workspaceId,
@@ -513,7 +515,8 @@ export default class TicketController {
       dto.targetTicketId,
     );
 
-    await this.ticketService.updateTicketSprintOrder(
+    await this.ticketService.updateTicketOrder(
+      'sprint_order_id',
       ticket,
       targetTicket.sprint_order_id,
       workspaceId,

--- a/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
+++ b/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
@@ -70,6 +70,7 @@ import User from '@/src/modules/user/domain/user.entity';
 import RequestTicketEpicUpdateDto from '../dto/ticket/ticket-epic.update.dto';
 import RequestTicketPriorityUpdateDto from '../dto/ticket/ticket-priority.update.dto';
 import RequestTicketEpicOrderUpdateDto from '../dto/ticket-epic-order.update.dto';
+import RequestTicketSprintOrderUpdateDto from '../dto/ticket/ticket-sprint-order.update.dto';
 
 @ApiTags('Workspace Ticket')
 @ApiBearerAuth('access-token')
@@ -488,6 +489,33 @@ export default class TicketController {
     await this.ticketService.updateTicketEpicOrder(
       ticket,
       targetTicket.epic_order_id,
+      workspaceId,
+    );
+    return CommonResponse.createResponseMessage({
+      statusCode: 200,
+      message: 'Ticket Epic 정렬을 변경합니다.',
+    });
+  }
+
+  @ApiOperation({ summary: 'TICKET Sprint Order 변경' })
+  @ApiBody({ type: RequestTicketSprintOrderUpdateDto })
+  @ApiResponse(TicketResponse.updateTicketState[200])
+  @ApiResponse(TicketResponse.updateTicketState[404])
+  @WorkspaceRole(RoleEnum.WRITER)
+  @UseGuards(WorkspaceRoleGuard)
+  @Patch('/sprintOrder')
+  public async updateTicketSprintOrder(
+    @Body() dto: RequestTicketSprintOrderUpdateDto,
+    @GetWorkspace() { workspaceId }: Workspace,
+  ) {
+    const ticket = await this.ticketService.findTicketById(dto.ticketId);
+    const targetTicket = await this.ticketService.findTicketById(
+      dto.targetTicketId,
+    );
+
+    await this.ticketService.updateTicketSprintOrder(
+      ticket,
+      targetTicket.sprint_order_id,
       workspaceId,
     );
     return CommonResponse.createResponseMessage({

--- a/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
+++ b/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
@@ -69,6 +69,7 @@ import Workspace from '@/src/modules/workspace/domain/workspace.entity';
 import User from '@/src/modules/user/domain/user.entity';
 import RequestTicketEpicUpdateDto from '../dto/ticket/ticket-epic.update.dto';
 import RequestTicketPriorityUpdateDto from '../dto/ticket/ticket-priority.update.dto';
+import RequestTicketEpicOrderUpdateDto from '../dto/ticket-epic-order.update.dto';
 
 @ApiTags('Workspace Ticket')
 @ApiBearerAuth('access-token')
@@ -465,6 +466,33 @@ export default class TicketController {
     return CommonResponse.createResponseMessage({
       statusCode: 200,
       message: 'Ticket 정렬을 변경합니다.',
+    });
+  }
+
+  @ApiOperation({ summary: 'TICKET Epic Order 변경' })
+  @ApiBody({ type: RequestTicketEpicOrderUpdateDto })
+  @ApiResponse(TicketResponse.updateTicketState[200])
+  @ApiResponse(TicketResponse.updateTicketState[404])
+  @WorkspaceRole(RoleEnum.WRITER)
+  @UseGuards(WorkspaceRoleGuard)
+  @Patch('/epicOrder')
+  public async updateTicketEpicOrder(
+    @Body() dto: RequestTicketEpicOrderUpdateDto,
+    @GetWorkspace() { workspaceId }: Workspace,
+  ) {
+    const ticket = await this.ticketService.findTicketById(dto.ticketId);
+    const targetTicket = await this.ticketService.findTicketById(
+      dto.targetTicketId,
+    );
+
+    await this.ticketService.updateTicketEpicOrder(
+      ticket,
+      targetTicket.epic_order_id,
+      workspaceId,
+    );
+    return CommonResponse.createResponseMessage({
+      statusCode: 200,
+      message: 'Ticket Epic 정렬을 변경합니다.',
     });
   }
 

--- a/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
+++ b/apps/core-server/src/modules/task/ticket/controller/ticket.controller.ts
@@ -488,9 +488,9 @@ export default class TicketController {
     );
 
     await this.ticketService.updateTicketOrder(
-      'epic_order_id',
+      'epicOrderId',
       ticket,
-      targetTicket.epic_order_id,
+      targetTicket.epicOrderId,
       workspaceId,
     );
     return CommonResponse.createResponseMessage({
@@ -516,9 +516,9 @@ export default class TicketController {
     );
 
     await this.ticketService.updateTicketOrder(
-      'sprint_order_id',
+      'sprintOrderId',
       ticket,
-      targetTicket.sprint_order_id,
+      targetTicket.sprintOrderId,
       workspaceId,
     );
     return CommonResponse.createResponseMessage({

--- a/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
+++ b/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
@@ -45,6 +45,22 @@ export default class Ticket extends BaseTimeEntity {
   orderId: number;
 
   @Column({
+    type: 'int',
+    comment: 'epic 내부 티켓 정렬 순서',
+    nullable: false,
+    default: 1,
+  })
+  epicOrderId: number;
+
+  @Column({
+    type: 'int',
+    comment: 'sprint 내부 티켓 정렬 순서',
+    nullable: false,
+    default: 1,
+  })
+  sprintOrderId: number;
+
+  @Column({
     type: 'enum',
     enum: PriorityEnum,
     default: PriorityEnum.MEDIUM,

--- a/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
+++ b/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
@@ -50,7 +50,7 @@ export default class Ticket extends BaseTimeEntity {
     nullable: false,
     default: 1,
   })
-  epicOrderId: number;
+  epic_order_id: number;
 
   @Column({
     type: 'int',
@@ -58,7 +58,7 @@ export default class Ticket extends BaseTimeEntity {
     nullable: false,
     default: 1,
   })
-  sprintOrderId: number;
+  sprint_order_id: number;
 
   @Column({
     type: 'enum',

--- a/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
+++ b/apps/core-server/src/modules/task/ticket/domain/ticket.entity.ts
@@ -47,18 +47,20 @@ export default class Ticket extends BaseTimeEntity {
   @Column({
     type: 'int',
     comment: 'epic 내부 티켓 정렬 순서',
+    name: 'epic_order_id',
     nullable: false,
     default: 1,
   })
-  epic_order_id: number;
+  epicOrderId: number;
 
   @Column({
     type: 'int',
     comment: 'sprint 내부 티켓 정렬 순서',
+    name: 'sprint_order_id',
     nullable: false,
     default: 1,
   })
-  sprint_order_id: number;
+  sprintOrderId: number;
 
   @Column({
     type: 'enum',

--- a/apps/core-server/src/modules/task/ticket/dto/ticket-epic-order.update.dto.ts
+++ b/apps/core-server/src/modules/task/ticket/dto/ticket-epic-order.update.dto.ts
@@ -1,0 +1,15 @@
+// ** Swagger Imports
+import { ApiProperty } from '@nestjs/swagger';
+
+// ** Pipe Imports
+import { IsNumber } from 'class-validator';
+
+export default class RequestTicketEpicOrderUpdateDto {
+  @ApiProperty({ example: 2 })
+  @IsNumber()
+  ticketId: number;
+
+  @ApiProperty({ example: 2 })
+  @IsNumber()
+  targetTicketId: number;
+}

--- a/apps/core-server/src/modules/task/ticket/dto/ticket/ticket-sprint-order.update.dto.ts
+++ b/apps/core-server/src/modules/task/ticket/dto/ticket/ticket-sprint-order.update.dto.ts
@@ -1,0 +1,15 @@
+// ** Swagger Imports
+import { ApiProperty } from '@nestjs/swagger';
+
+// ** Pipe Imports
+import { IsNumber } from 'class-validator';
+
+export default class RequestTicketSprintOrderUpdateDto {
+  @ApiProperty({ example: 2 })
+  @IsNumber()
+  ticketId: number;
+
+  @ApiProperty({ example: 2 })
+  @IsNumber()
+  targetTicketId: number;
+}

--- a/apps/core-server/src/modules/task/ticket/service/ticket.service.ts
+++ b/apps/core-server/src/modules/task/ticket/service/ticket.service.ts
@@ -575,116 +575,31 @@ export default class TicketService {
    * 티켓 정렬 순서 변경 - orderId (기본)
    */
   public async updateTicketOrder(
+    orderField: NumericFields<Ticket>,
     ticket: Ticket,
     targetOrderId: number,
     workspaceId: number,
   ): Promise<void> {
-    if (ticket.orderId > targetOrderId) {
+    if (ticket[orderField] > targetOrderId) {
       const list = await this.findMoreTicketList(
-        'orderId',
-        ticket.orderId,
+        orderField,
+        ticket[orderField],
         targetOrderId,
         workspaceId,
       );
 
-      await this.updateOrder(list, true, ticket, targetOrderId, 'orderId');
+      await this.updateOrder(list, true, ticket, targetOrderId, orderField);
     }
 
-    if (ticket.orderId < targetOrderId) {
+    if (ticket[orderField] < targetOrderId) {
       const list = await this.findLessTicketList(
-        'orderId',
-        ticket.orderId,
+        orderField,
+        ticket[orderField],
         targetOrderId,
         workspaceId,
       );
 
-      await this.updateOrder(list, false, ticket, targetOrderId, 'orderId');
-    }
-  }
-
-  /**
-   * 티켓 정렬 순서 변경 - epicOrderId
-   */
-  public async updateTicketEpicOrder(
-    ticket: Ticket,
-    targetOrderId: number,
-    workspaceId: number,
-  ): Promise<void> {
-    if (ticket.epic_order_id > targetOrderId) {
-      const list = await this.findMoreTicketList(
-        'epic_order_id',
-        ticket.epic_order_id,
-        targetOrderId,
-        workspaceId,
-      );
-
-      await this.updateOrder(
-        list,
-        true,
-        ticket,
-        targetOrderId,
-        'epic_order_id',
-      );
-    }
-
-    if (ticket.epic_order_id < targetOrderId) {
-      const list = await this.findLessTicketList(
-        'epic_order_id',
-        ticket.epic_order_id,
-        targetOrderId,
-        workspaceId,
-      );
-
-      await this.updateOrder(
-        list,
-        false,
-        ticket,
-        targetOrderId,
-        'epic_order_id',
-      );
-    }
-  }
-
-  /**
-   * 티켓 정렬 순서 변경 - epicOrderId
-   */
-  public async updateTicketSprintOrder(
-    ticket: Ticket,
-    targetOrderId: number,
-    workspaceId: number,
-  ): Promise<void> {
-    if (ticket.sprint_order_id > targetOrderId) {
-      const list = await this.findMoreTicketList(
-        'sprint_order_id',
-        ticket.sprint_order_id,
-        targetOrderId,
-        workspaceId,
-      );
-
-      await this.updateOrder(
-        list,
-        true,
-        ticket,
-        targetOrderId,
-        'sprint_order_id',
-      );
-    }
-
-    if (ticket.sprint_order_id < targetOrderId) {
-      const list = await this.findLessTicketList(
-        'sprint_order_id',
-        ticket.sprint_order_id,
-        targetOrderId,
-        workspaceId,
-      );
-
-      await this.updateOrder(
-        list,
-        false,
-        ticket,
-        targetOrderId,
-        'sprint_order_id',
-      );
+      await this.updateOrder(list, false, ticket, targetOrderId, orderField);
     }
   }
 

--- a/apps/core-server/src/modules/task/ticket/service/ticket.service.ts
+++ b/apps/core-server/src/modules/task/ticket/service/ticket.service.ts
@@ -646,6 +646,49 @@ export default class TicketService {
   }
 
   /**
+   * 티켓 정렬 순서 변경 - epicOrderId
+   */
+  public async updateTicketSprintOrder(
+    ticket: Ticket,
+    targetOrderId: number,
+    workspaceId: number,
+  ): Promise<void> {
+    if (ticket.sprint_order_id > targetOrderId) {
+      const list = await this.findMoreTicketList(
+        'sprint_order_id',
+        ticket.sprint_order_id,
+        targetOrderId,
+        workspaceId,
+      );
+
+      await this.updateOrder(
+        list,
+        true,
+        ticket,
+        targetOrderId,
+        'sprint_order_id',
+      );
+    }
+
+    if (ticket.sprint_order_id < targetOrderId) {
+      const list = await this.findLessTicketList(
+        'sprint_order_id',
+        ticket.sprint_order_id,
+        targetOrderId,
+        workspaceId,
+      );
+
+      await this.updateOrder(
+        list,
+        false,
+        ticket,
+        targetOrderId,
+        'sprint_order_id',
+      );
+    }
+  }
+
+  /**
    * 티켓의 정렬 순서 변경
    */
   private async updateOrder(


### PR DESCRIPTION
- 작업 내용
기본, 에픽, 스프린트 관련 티켓 정렬 분리 및 API 작성

- 리뷰어가 봐야할 사항
updateOrder, findMoreTicketList, findLessTicketList 메소드 

- 궁금한 사항
epicOrderId로 하면 안되고 epic_order_id로 했을때만 db에서 찾아오던데 원래 그런건가요?